### PR TITLE
chore(deps): update dependency @sveltejs/kit to v2.21.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@eslint/js": "9.27.0",
         "@sveltejs/adapter-auto": "6.0.1",
         "@sveltejs/adapter-static": "3.0.8",
-        "@sveltejs/kit": "2.21.0",
+        "@sveltejs/kit": "2.21.1",
         "@sveltejs/vite-plugin-svelte": "5.0.3",
         "@types/d3": "7.4.3",
         "@types/d3-array": "3.2.1",
@@ -1522,9 +1522,9 @@
       }
     },
     "node_modules/@sveltejs/kit": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.21.0.tgz",
-      "integrity": "sha512-kvu4h9qXduiPk1Q1oqFKDLFGu/7mslEYbVaqpbBcBxjlRJnvNCFwEvEwKt0Mx9TtSi8J77xRelvJobrGlst4nQ==",
+      "version": "2.21.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.21.1.tgz",
+      "integrity": "sha512-vLbtVwtDcK8LhJKnFkFYwM0uCdFmzioQnif0bjEYH1I24Arz22JPr/hLUiXGVYAwhu8INKx5qrdvr4tHgPwX6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@eslint/js": "9.27.0",
     "@sveltejs/adapter-auto": "6.0.1",
     "@sveltejs/adapter-static": "3.0.8",
-    "@sveltejs/kit": "2.21.0",
+    "@sveltejs/kit": "2.21.1",
     "@sveltejs/vite-plugin-svelte": "5.0.3",
     "@types/d3": "7.4.3",
     "@types/d3-array": "3.2.1",


### PR DESCRIPTION
chore(deps): update dependency @sveltejs/kit to v2.21.1
Renovate is giving a strange `Artifact update problem`. Doing this on my own, then.