### PR TITLE
Remove svelte-json-tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "d3": "7.9.0",
         "layerchart": "1.0.11",
         "prismjs": "1.30.0",
-        "svelte-json-tree": "2.2.0",
         "svelte-ux": "1.0.6",
         "tailwindcss": "4.1.7"
       },
@@ -5868,14 +5867,6 @@
         "svelte": {
           "optional": true
         }
-      }
-    },
-    "node_modules/svelte-json-tree": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/svelte-json-tree/-/svelte-json-tree-2.2.0.tgz",
-      "integrity": "sha512-zcfepTrJ6xhpdgRZEujmiFh+ainRw7HO4Bsoh8PMAsm7fkgUPtnrZi3An8tmCFY8jajYhMrauHsd1S1XTeuiCw==",
-      "peerDependencies": {
-        "svelte": "^4.0.0"
       }
     },
     "node_modules/svelte-preprocess": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "d3": "7.9.0",
     "layerchart": "1.0.11",
     "prismjs": "1.30.0",
-    "svelte-json-tree": "2.2.0",
     "svelte-ux": "1.0.6",
     "tailwindcss": "4.1.7"
   },


### PR DESCRIPTION
Remove svelte-json-tree
A possible cause of the Renovate `Artifact update problem`, and not a package currently in use, anyway.