### PR TITLE
Delete `.npmrc` to remove `engine-strict=true`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-engine-strict=true


### PR DESCRIPTION
Remove `engine-strict=true`
No longer necessary; was because of one package that is gone now